### PR TITLE
Changes initialization api to accept default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Is your backend stubborn? [![Build Status](https://travis-ci.org/zeachco/stubborn-server.png)](https://travis-ci.org/zeachco/stubborn-server)
 NodeJS Stub server for test and dev purposes
 
-It allow :
+It allows:
 - mocking with static json
 - mocking with dynamic request handlers based on [Express  requests](http://expressjs.com/en/4x/api.html#req)
 - storing/accessing a memory database
@@ -49,11 +49,12 @@ then start server with something like this
 
 ```javascript
 const Stubborn = require('stubborn-server');
+const stubbornClient = Stubborn();
 
-Stubborn.start(/* config to extend ./stubborn.js if required */);
+stubbornClient.start(/* config to extend ./stubborn.js if required */);
 
 // from this point, you may run your queries
 
-// Stubborn.stop();
+// stubbornClient.stop();
 
 ```

--- a/demo.js
+++ b/demo.js
@@ -1,4 +1,4 @@
-const Stubborn = require('./'); // stubborn-server
+const Stubborn = require('./')(); // stubborn-server
 
 Stubborn.start({
   verbose: true,

--- a/index.js
+++ b/index.js
@@ -2,9 +2,11 @@
 
 const fileConfig = require('./server/config');
 
-const api = {};
-api.log = require('./server/logger');
-api.start = (config) => fileConfig(config) && require('./server')(config) && api;
-api.stop = () => require('./server/app').process.close() || api;
+module.exports = defaultConfig => {
+  const api = {};
+  api.log = require('./server/logger');
+  api.start = config => fileConfig(Object.assign({}, config, defaultConfig)) && require('./server')(config) && api;
+  api.stop = () => require('./server/app').process.close() || api;
+  return api;
+};
 
-module.exports = api;

--- a/tests/run.js
+++ b/tests/run.js
@@ -1,4 +1,4 @@
-var stub = require('..');
+var stub = require('..')();
 stub.start({
   verbose: true,
   servePort: 9876


### PR DESCRIPTION
⚠️ Breaking change

Changes API to return a function that expects a config to be used as default config value for further start/stops.

Now the API would look like this:

```js
var stubborn = require('stubborn-server');

// Initializes with an optional config
var stubbornClient = stubborn({
  verbose: false,
  pathToMocks: 'foo',
  servePort: 9999
});
stubbornClient.start({
  namespace: 'lorem'
});
stubbornClient.stop();
```

@zeachco 