### PR TITLE
pathToMocks config accepts absolute paths

### DIFF
--- a/server/mocks.js
+++ b/server/mocks.js
@@ -19,9 +19,11 @@ module.exports = config => {
 
   const requireMock = (req) => {
     let mock = null;
+    const pathToMocks = config.pathToMocks[0] === '/' ?
+      config.pathToMocks :
+      path.join(process.cwd(), config.pathToMocks);
     const file = path.join(
-      process.cwd(),
-      config.pathToMocks,
+      pathToMocks,
       req.url.split('?')[0],
       req.method.toLowerCase(),
       config.namespace ? '-' + config.namespace : ''


### PR DESCRIPTION
I want to be able to use the `pathToMocks` config with a value completely outside of the scope of `process.cwd()`.

This PR introduces a test to check if `pathToMocks` is an absolute path (usually result from a `path.join(__dirname, 'location')` or `path.join(process.cwd(), 'location')`)

@zeachco 