### PR TITLE
Fixes console.log scope

### DIFF
--- a/server/logger.js
+++ b/server/logger.js
@@ -23,7 +23,7 @@ var wrap = (color, args) => {
   }
   args = args.map(t => typeof t === 'object' ? JSON.stringify(t, null, 2) : t).map(t => chalk[color].bold(t));
   args.splice(0, 0, prefix);
-  global.console.log.apply(this, args);
+  global.console.log.apply(global.console, args);
 };
 
 module.exports = {


### PR DESCRIPTION
@zeachco I remember I told you to change this line yesterday, guess what, it just exploded in our face this morning while I was testing with @stephanefbouchard 😂 

node debugging tools weren't happy with `console.log` not being binded to its correct scope, anyways, this should fix it 🌈 