### PR TITLE
Fallbacks is now an array of objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,16 @@ module.exports = {
   namespace: '', // help switching between different senarios
   pathToMocks: 'mock-examples', // mock folder relative path
   servePort: 8059,
-  fallbacks: {
-    '/assets/*': '/path/to/static/folder',
-    '/*': 'localhost:3000'
-  }
+  fallbacks: [
+    {
+      url: '/assets/*',
+      target: '/path/to/static/folder'
+    },
+    {
+      url: '/*':,
+      target: 'localhost:3000'
+    }
+  ]
 };
 ```
 
@@ -34,10 +40,16 @@ or a `stubborn.json` file
   "namespace": "",
   "pathToMocks": "mock-examples",
   "servePort": 8059,
-  "fallbacks": {
-    "/assets/*": "/path/to/static/folder",
-    "/*": "localhost:3000"
-  }
+  "fallbacks": [
+    {
+      url: "/assets/*",
+      target: "/path/to/static/folder"
+    },
+    {
+      url: "/*",
+      target: "localhost:3000"
+    }
+  ]
 }
 ```
 

--- a/server/fallback.js
+++ b/server/fallback.js
@@ -5,11 +5,10 @@ const express = require('express');
 const app = require('./app');
 const config = require('./config').get();
 
-Object.keys(config.fallbacks).forEach(key => {
-  let target = config.fallbacks[key];
-  if (target.indexOf(':') > -1) {
-    app.use(key, (req, res, next) => {
-      proxy(target, {
+config.fallbacks.forEach(item => {
+  if (item.target.indexOf(':') > -1) {
+    app.use(item.url, (req, res, next) => {
+      proxy(item.target, {
         forwardPath: function(req) {
           return require('url').parse(req.url).path;
         },
@@ -20,6 +19,6 @@ Object.keys(config.fallbacks).forEach(key => {
       })(req, res, next);
     });
   } else { // We assume the target is a local folder if not an url
-    app.use(key.replace(/\*$/, ''), express.static(target));
+    app.use(item.url.replace(/\*$/, ''), express.static(item.target));
   }
 });

--- a/test.js
+++ b/test.js
@@ -8,9 +8,12 @@ const testConfig = {
   verbose: false,
   namespace: '',
   pathToMocks: 'demo/dynamic-mocks-examples',
-  fallbacks: {
-    '/home/*': 'demo/static/'
-  }
+  fallbacks: [
+    {
+      url: '/home/*',
+      target: 'demo/static/'
+    }
+  ]
 };
 
 test.beforeEach(() => {


### PR DESCRIPTION
In reality we need the "fallbacks" config option to be an **ordered** list, since `express.use` takes in account the order in which the urls are declared.

This PR allow us to take advantage of that to have specific nested urls that should override more generic ones, example: 

```
'foo/bar': '/get/from/path',
'foo/*': '/generic/path'
```

⚠️ Breaking change, v0.5.0 advised after merging