### PR TITLE
Adding CORS support

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -8,5 +8,10 @@ app.use(bodyParser.urlencoded({
   extended: false
 }));
 app.use(bodyParser.json());
+app.use(function(req, res, next) {
+	res.header("Access-Control-Allow-Origin", "*");
+	res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+	next();
+});
 
 module.exports = app;


### PR DESCRIPTION
Use case: The content is served from localhost:8080 and the stubborn server is running on localhost:3300, it is still considered a cross-origin request.