### PR TITLE
Added plugin system with support to loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Mocks can be specified in three ways:
 The way you choose depends on the needs of your project. You may also
 mix and match as the options are not exclusive.
 
-#### Attaching express handlers
+### Attaching express handlers
 
 When creating your mock server, a reference to the underlying raw express app
 is available. You can attach any response handlers you want:
@@ -126,7 +126,7 @@ stub.start();
 stub.stop();
 ```
 
-#### Including express handlers
+### Including express handlers
 
 Instead of manually attaching handlers to the app, you may specify paths to
 express handlers. The handlers will then be `require()`ed for you.
@@ -162,7 +162,7 @@ module.exports = (app, stub) => {
 };
 ```
 
-#### Configuration-driven
+### Configuration-driven
 
 By default, when the server recieves a request it will look into the directory
 specified by the `pathToMocks` configuration option for a mock response.
@@ -200,5 +200,28 @@ and a `post.json` mock that returns the same mock response data:
 {
   "hello": "world"
 }
-
 ```
+
+### Plugins
+
+A plugin architecture allows you to extend even more the custom functionality of your server.
+
+#### Custom loaders
+
+Add your own custom loader that takes precedence over the default behavior of file system lookup and the `fallbacks` property - this way even if your loader throws you can still rely on the standard functionality.
+
+Here is an example of a custom loader that uses sent data in order to load a mock:
+
+```js
+stub.start({
+  plugins: [
+    {
+      loader: (req, { pathToMocks }) => {
+        return require(path.join(pathToMocks, req.body.data);
+      }
+    }
+  ]
+});
+```
+
+> NOTE: you may also define multiple loaders, allowing you to have multiple custom fallbacks systems.

--- a/server/config.js
+++ b/server/config.js
@@ -45,7 +45,11 @@ module.exports = {
     });
 
     config.includes = config.includes || [];
+    config.plugins = config.plugins || [];
     log.debug('Server configuration', config);
   },
-  get: () => config
+  get: () => config,
+  unset: (keys) => {
+    [].concat(keys).forEach(key => { delete config[key]; });
+  }
 };

--- a/server/mocks.js
+++ b/server/mocks.js
@@ -19,7 +19,7 @@ module.exports = app => {
   app.use((req, res, next) => {
     let mocker = null;
     try {
-      mocker = pathResolver(req);
+      mocker = pathResolver(req, utils);
       try {
         MockBehaviours[typeof mocker](mocker, req, res);
         log.mock(`${req.method} ${req.url}`);

--- a/test.js
+++ b/test.js
@@ -186,6 +186,63 @@ test('custom variable passed trough configuration', t => {
   });
 });
 
+test('custom path resolver', t => {
+  let target = 'http://127.0.0.1:' + defaultTestConfig.servePort + '/custom-path-resolver';
+
+  return new Promise((resolve, reject) => {
+    stub.start(Object.assign({}, defaultTestConfig, {
+      plugins: [
+        {
+          loader: () => ({ a: 'a' })
+        }
+      ]
+    }));
+    request(target, function(error, response, body) {
+      if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
+        t.truthy(data);
+        t.deepEqual(data, { a: 'a' });
+        resolve();
+      } else {
+        reject(error || response.statusCode + ' ' + response.body);
+      }
+      stub.stop();
+      const config = require('./server/config');
+      config.unset('plugins');
+    });
+  });
+});
+
+test('multiple custom path resolver', t => {
+  let target = 'http://127.0.0.1:' + defaultTestConfig.servePort + '/custom-path-resolver';
+
+  return new Promise((resolve, reject) => {
+    stub.start(Object.assign({}, defaultTestConfig, {
+      plugins: [
+        {
+          loader: () => { throw 'failed'; },
+        },
+        {
+          loader: () => ({ b: 'b' })
+        }
+      ]
+    }));
+    request(target, function(error, response, body) {
+      if (!error && response.statusCode == 200) {
+        let data = JSON.parse(body);
+        t.truthy(data);
+        t.deepEqual(data, { b: 'b' });
+        resolve();
+      } else {
+        reject(error || response.statusCode + ' ' + response.body);
+      }
+      stub.stop();
+      const config = require('./server/config');
+      config.unset('plugins');
+    });
+  });
+});
+
 require('./tests/config-app')({
   stub,
   fileConfig,


### PR DESCRIPTION
Added a webpack-inspired plugin system that works a bit like:

```js
stub.start({
  plugins: [
    {
      loader: (req, { pathToMocks }) => {
        return require(path.join(pathToMocks, req.body.data);
      }
    }
  ]
});
```

In this first implementation it supports **loaders** which are a system to allow the user to have custom ways to resolve its own mocks.

heads up @zeachco 