### PR TITLE
Wrap function mocker with force-require

### DIFF
--- a/server/force-require.js
+++ b/server/force-require.js
@@ -14,7 +14,15 @@ const restoreRequire = () => {
   Module.prototype.require = originalRequire;
 };
 
+const wrapForceRequire = (fn, ...args) => {
+  forceRequire();
+  const result = fn(...args);
+  restoreRequire();
+  return result;
+};
+
 module.exports = {
   forceRequire,
-  restoreRequire
+  restoreRequire,
+  wrapForceRequire
 };

--- a/server/mocks.js
+++ b/server/mocks.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const pathResolver = require('./path-resolver');
+const { wrapForceRequire } = require('./force-require');
 
 module.exports = stub => {
   const { app, log } = stub;
 
   const MockBehaviours = {
-    'function': (mocker, req, res) => mocker(req, res, stub, mocker),
+    'function': (mocker, req, res) => wrapForceRequire(() => mocker(req, res, stub, mocker)),
     'object': (data, req, res) => res.json(data),
     'null': (data, req, res) => res.end()
   };


### PR DESCRIPTION
Followup to #45. Also wraps the function mocker with the force require util so `require`s made dynamically inside the function mockers are not cached either.