### PR TITLE
feature - Added CORS capabilities. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2265,6 +2265,15 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -5423,8 +5432,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "body-parser": "^1.19.0",
     "chalk": "^3.0.0",
     "cookie-parser": "^1.4.4",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-http-proxy": "^1.6.0"
   },

--- a/server/app.js
+++ b/server/app.js
@@ -3,6 +3,7 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
+const cors = require('cors');
 
 module.exports = () => {
   const app = express();
@@ -11,11 +12,7 @@ module.exports = () => {
   }));
   app.use(bodyParser.json());
   app.use(cookieParser());
+  app.use(cors());
 
-  app.use(function(req, res, next) {
-    res.header('Access-Control-Allow-Origin', '*');
-    res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
-    next();
-  });
   return app;
 };


### PR DESCRIPTION
Fixes zeachco/stubborn-server#53

This PR adds the traditional `cors` capabilities using the official express/cors package with the default configurations which fit most cases.

@ruyadorno 
I am struggling to find a test scenario to create that would not be just testing if the `cors` package does what it is supposed to do. Do you have any ideas on that ?
